### PR TITLE
Fix RegisterStaff employee creation bug

### DIFF
--- a/register_client.go
+++ b/register_client.go
@@ -25,10 +25,14 @@ func (a *App) RegisterClient(email string, accountId uint) error {
 }
 
 func (a *App) RegisterStaff(email string, accountId uint) error {
-	// Create a blank user and client if they don't already exist
+	// Create the user record first
 	user := User{Email: email}
 	a.DB.Save(&user)
-	a.DB.Save(&Employee{User: user})
+
+	// Link the newly created user to an employee record using the user's ID
+	employee := Employee{UserID: user.ID}
+	a.DB.Create(&employee)
+
 	user.Password = DEFAULT_PASSWORD
 	user.Role = UserRoleStaff.String()
 	user.AccountID = accountId

--- a/user_test.go
+++ b/user_test.go
@@ -124,10 +124,14 @@ func TestRegisterStaff(t *testing.T) {
 
 	// Create a custom register function that doesn't send emails
 	registerStaff := func(email string, accountID uint) error {
-		// Create a blank user and staff
+		// Create the user record first
 		user := User{Email: email}
 		app.DB.Save(&user)
-		app.DB.Save(&Employee{User: user})
+
+		// Link the newly created user to an employee record using the user's ID
+		employee := Employee{UserID: user.ID}
+		app.DB.Create(&employee)
+
 		user.Password = DEFAULT_PASSWORD
 		user.Role = UserRoleStaff.String()
 		user.AccountID = accountID


### PR DESCRIPTION
## Summary
- link newly created user to employee record in RegisterStaff
- update corresponding test to reflect new behavior

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_684174859180832fbbf3031b0b227f43