### PR TITLE
Add DB reload check for UpdateInvoiceTotals

### DIFF
--- a/invoice_test.go
+++ b/invoice_test.go
@@ -171,6 +171,11 @@ func TestUpdateInvoiceTotals(t *testing.T) {
 	// Update the invoice totals
 	app.UpdateInvoiceTotals(&invoice)
 
+	// Reload the invoice from the DB to ensure totals were persisted
+	if err := db.First(&invoice, invoice.ID).Error; err != nil {
+		t.Fatalf("Failed to reload invoice: %v", err)
+	}
+
 	// Verify totals
 	// Hours: 2 + 3 = 5 hours
 	// Fees: 5 hours * $150/hour = $750


### PR DESCRIPTION
Olodort: experiment purely coded and drafted by OpenAI Codex. See #cronos channel for context.

## Summary
- verify invoice totals persist by reloading the record in `TestUpdateInvoiceTotals`

## Testing
- `go test ./...` *(fails: cannot fetch modules)*

------
https://chatgpt.com/codex/tasks/task_b_68417ceb610c832fba2bcfa5a3bcb8d8