### PR TITLE
Improve security and entry validation

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -376,13 +376,11 @@ func (a *App) SaveInvoiceToGCS(invoice *Invoice) error {
 	if _, err := writer.Write(pdfBytes); err != nil {
 		return err
 	}
-	writer.Close()
-
-	// Set the object to be publicly accessible
-	acl := bucket.Object(objectName).ACL()
-	if err := acl.Set(ctx, storage.AllUsers, storage.RoleReader); err != nil {
+	if err := writer.Close(); err != nil {
 		return err
 	}
+
+	// keep object private and store link
 
 	// save the public invoice URL to the database
 	invoice.GCSFile = "https://storage.googleapis.com/" + a.Bucket + "/" + objectName

--- a/register_client.go
+++ b/register_client.go
@@ -1,6 +1,8 @@
 package cronos
 
-import "github.com/pkg/errors"
+import (
+	"github.com/pkg/errors"
+)
 
 var ErrUserAlreadyExists = errors.New("user already exists")
 
@@ -15,13 +17,17 @@ func (a *App) RegisterClient(email string, accountId uint) error {
 	} else {
 		return ErrUserAlreadyExists
 	}
-	user.Password = DEFAULT_PASSWORD
+	hashed, err := hashPassword(DEFAULT_PASSWORD)
+	if err != nil {
+		return err
+	}
+	user.Password = hashed
 	user.Role = UserRoleClient.String()
 	user.AccountID = accountId
 	a.DB.Save(&user)
 	// Send the email to the user
-	err := a.EmailFromAdmin(EmailTypeRegisterClient, email)
-	return err
+	sendErr := a.EmailFromAdmin(EmailTypeRegisterClient, email)
+	return sendErr
 }
 
 func (a *App) RegisterStaff(email string, accountId uint) error {
@@ -29,11 +35,15 @@ func (a *App) RegisterStaff(email string, accountId uint) error {
 	user := User{Email: email}
 	a.DB.Save(&user)
 	a.DB.Save(&Employee{User: user})
-	user.Password = DEFAULT_PASSWORD
+	hashed, err := hashPassword(DEFAULT_PASSWORD)
+	if err != nil {
+		return err
+	}
+	user.Password = hashed
 	user.Role = UserRoleStaff.String()
 	user.AccountID = accountId
 	a.DB.Save(&user)
 	// Send the email to the user
-	err := a.EmailFromAdmin(EmailTypeRegisterStaff, email)
-	return err
+	sendErr := a.EmailFromAdmin(EmailTypeRegisterStaff, email)
+	return sendErr
 }

--- a/seed_database.go
+++ b/seed_database.go
@@ -41,11 +41,12 @@ func (a *App) SeedDatabase() {
 
 	if !userExists {
 		// If the user doesn't exist, create a default one (this shouldn't happen if the dev user was registered)
+		hashed, _ := hashPassword(DEFAULT_PASSWORD)
 		devUser = User{
 			Email:    "dev@example.com",
 			IsAdmin:  true,
 			Role:     UserRoleAdmin.String(),
-			Password: DEFAULT_PASSWORD,
+			Password: hashed,
 		}
 		a.DB.Create(&devUser)
 		a.DB.Model(&devUser).Update("id", 1)
@@ -65,36 +66,37 @@ func (a *App) SeedDatabase() {
 	}
 
 	// Create additional users for staff
+	hashed, _ := hashPassword(DEFAULT_PASSWORD)
 	users := []User{
 		{
 			Email:    "nate@snowpack-data.com",
 			IsAdmin:  true,
 			Role:     UserRoleAdmin.String(),
-			Password: DEFAULT_PASSWORD,
+			Password: hashed,
 		},
 		{
 			Email:    "kevin@snowpack-data.com",
 			IsAdmin:  true,
 			Role:     UserRoleStaff.String(),
-			Password: DEFAULT_PASSWORD,
+			Password: hashed,
 		},
 		{
 			Email:    "david@snowpack-data.com",
 			IsAdmin:  false,
 			Role:     UserRoleStaff.String(),
-			Password: DEFAULT_PASSWORD,
+			Password: hashed,
 		},
 		{
 			Email:    "john@snowpack-data.com",
 			IsAdmin:  false,
 			Role:     UserRoleStaff.String(),
-			Password: DEFAULT_PASSWORD,
+			Password: hashed,
 		},
 		{
 			Email:    "jane@snowpack-data.com",
 			IsAdmin:  false,
 			Role:     UserRoleStaff.String(),
-			Password: DEFAULT_PASSWORD,
+			Password: hashed,
 		},
 	}
 	_ = a.DB.Create(&users)


### PR DESCRIPTION
## Summary
- hash passwords instead of storing the DEFAULT_PASSWORD in plaintext
- validate Entry end time occurs after start time
- keep invoices and bills private in GCS
- avoid panics and fatal exits when regenerating PDFs
- update seed data and tests for new logic

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6841817510d8832fa87fe2ca5230c672